### PR TITLE
Add configuration to support API

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -5,7 +5,8 @@
   "main": "app.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node dist/app.js"
+    "start": "node dist/app.js",
+    "build": "npx tsc"
   },
   "type": "module",
   "author": "",

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -1,12 +1,12 @@
 import express from 'express';
 import * as bodyParser from 'body-parser';
-import { credsRouter } from './routes/credentialsRoute';
+import { credsRouter } from './routes/credentialsRoute.js';
 
 const app = express();
 const port = process.env.PORT || 3000; // Set your desired port
 
 // Middleware
-app.use(bodyParser.json());
+//app.use(bodyParser.json());
 
 app.use('/api/credentials', credsRouter);
 

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -1,12 +1,12 @@
 import express from 'express';
-import * as bodyParser from 'body-parser';
+import bodyParser from 'body-parser'
 import { credsRouter } from './routes/credentialsRoute.js';
 
 const app = express();
 const port = process.env.PORT || 3000; // Set your desired port
 
 // Middleware
-//app.use(bodyParser.json());
+app.use(bodyParser.json());
 
 app.use('/api/credentials', credsRouter);
 

--- a/api/src/controllers/credentialsController.ts
+++ b/api/src/controllers/credentialsController.ts
@@ -1,19 +1,23 @@
 // controllers/credentialsController.ts
 import { Request, Response } from "express";
 import { CredentialMetadata } from "../models/CredentialMetadata.js";
-// import { CredentialGenerator, CredentialRepository } from "../../../mentat/src/index";
+ //import { CredentialMetadata, CredentialGenerator, CredentialRepository } from "../../../mentat/src/index";
 
 
 export const generateCredentials = (req: Request, res: Response) => {
     const creds: CredentialMetadata = req.body as CredentialMetadata;
-
-    GenerateCredentialFile(creds);
-
-    DeployCredential("");
-
-    AddFirebaseMetadata("", "");
+    console.log("Started generating credential");
     res.status(200)
-    .send("Credential Generated @ " + new Date().toISOString());
+    .send(creds);
+    // GenerateCredentialFile(creds);
+    
+    // DeployCredential("");
+    // console.log("Storing credential");
+    // new CredentialRepository().AddCredential(creds);
+    // console.log("Storedcredential");
+
+    // res.status(200)
+    // .send("Credential Generated @ " + new Date().toISOString());
 };
 
 function GenerateCredentialFile(json: CredentialMetadata): string {
@@ -31,6 +35,7 @@ function GenerateCredentialFile(json: CredentialMetadata): string {
     // ToDo: Make generate and save accept a CredentialMetadata type and not json
     //generator.generateAndSave(json, template);
 
+    console.log("Credential generated");
 
     return "Credential generated"
 }

--- a/api/src/controllers/credentialsController.ts
+++ b/api/src/controllers/credentialsController.ts
@@ -1,6 +1,6 @@
 // controllers/credentialsController.ts
 import { Request, Response } from "express";
-import { CredentialMetadata } from "../models/CredentialMetadata";
+import { CredentialMetadata } from "../models/CredentialMetadata.js";
 // import { CredentialGenerator, CredentialRepository } from "../../../mentat/src/index";
 
 
@@ -12,9 +12,8 @@ export const generateCredentials = (req: Request, res: Response) => {
     DeployCredential("");
 
     AddFirebaseMetadata("", "");
-
-    return "Credential Generated";
-
+    res.status(200)
+    .send("Credential Generated @ " + new Date().toISOString());
 };
 
 function GenerateCredentialFile(json: CredentialMetadata): string {

--- a/api/src/controllers/credentialsController.ts
+++ b/api/src/controllers/credentialsController.ts
@@ -7,17 +7,17 @@ import { CredentialMetadata } from "../models/CredentialMetadata.js";
 export const generateCredentials = (req: Request, res: Response) => {
     const creds: CredentialMetadata = req.body as CredentialMetadata;
     console.log("Started generating credential");
-    res.status(200)
-    .send(creds);
-    // GenerateCredentialFile(creds);
     
-    // DeployCredential("");
-    // console.log("Storing credential");
+     GenerateCredentialFile(creds);
+    
+     DeployCredential("");
+     console.log("Storing credential");
     // new CredentialRepository().AddCredential(creds);
-    // console.log("Storedcredential");
+     console.log("Storedcredential");
 
-    // res.status(200)
-    // .send("Credential Generated @ " + new Date().toISOString());
+     creds.created = new Date();
+     res.status(200)
+     .send(creds);
 };
 
 function GenerateCredentialFile(json: CredentialMetadata): string {

--- a/api/src/routes/credentialsRoute.ts
+++ b/api/src/routes/credentialsRoute.ts
@@ -1,6 +1,6 @@
 // routes/credentialsRoute.ts
 import express from 'express';
-import { generateCredentials } from '../controllers/credentialsController';
+import { generateCredentials } from '../controllers/credentialsController.js';
 
 export const credsRouter = express.Router();
 

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -1,109 +1,15 @@
 {
   "compilerOptions": {
-    /* Visit https://aka.ms/tsconfig to read more about this file */
-
-    /* Projects */
-    // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
-    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
-    // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
-    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
-    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
-    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
-
-    /* Language and Environment */
-    "target": "es2016" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
-    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
-    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
-    // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
-    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
-    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
-    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
-    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
-    // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
-    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
-    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
-    // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
-
-    /* Modules */
-    "module": "ES2015" /* Specify what module code is generated. */,
-    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
-    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
-    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
-    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
-    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
-    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
-    // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
-    // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
-    // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
-    // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
-    // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
-    // "resolveJsonModule": true,                        /* Enable importing .json files. */
-    // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
-    // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
-
-    /* JavaScript Support */
-    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
-    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
-    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
-
-    /* Emit */
-    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
-    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
-    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
-    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
-    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
-    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    "outDir": "./dist" /* Specify an output folder for all emitted files. */,
-    // "removeComments": true,                           /* Disable emitting comments. */
-    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
-    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
-    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
-    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
-    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
-    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
-    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
-    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
-    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
-    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
-    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
-    // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
-    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
-    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
-
-    /* Interop Constraints */
-    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
-    // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
-    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
-    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
-    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
-    "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
-
-    /* Type Checking */
-    "strict": true /* Enable all strict type-checking options. */,
-    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
-    // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
-    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
-    // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
-    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
-    // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
-    // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
-    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
-    // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
-    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
-    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
-    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
-    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
-    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
-    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
-    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
-    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
-    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
-
-    /* Completeness */
-    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": true /* Skip type checking all .d.ts files. */
+    "target": "es2020",
+    "module": "es2022",
+    "lib": ["dom", "esnext"],
+    "outDir": "./dist",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "allowJs": true,
+    "declaration": true,
+    "sourceMap": true,
   }
 }


### PR DESCRIPTION
## How to run
- navigate to api folder
- npm install
- npm run build
- npm run start
- Invoke API using Postman or the like 
- URL like http://localhost:3000/api/credentials
## Sample json
`{
    "name": "License",
    "fields":[
        { "name": "number", "type": "CircuitString"},
        { "name": "name", "type": "CircuitString"}
    ]
}`

## Details of change
Made some minor changes to configure the api
- Add the build command to package.json
- changed the tsconfig
- included the .js file extension in imports
- added a res.send() call at the end of the controller to complete the request